### PR TITLE
Include array handling in setQueryString()

### DIFF
--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -325,7 +325,7 @@ class Eseye
     {
         foreach ($query as $key => $value) {
             if (is_array($value)) {
-                $query[$key] = implode(",", $value);
+                $query[$key] = implode(',', $value);
             }
         }
 

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -323,6 +323,11 @@ class Eseye
      */
     public function setQueryString(array $query): self
     {
+        foreach ($query as $key => $value) {
+            if (is_array($value)) {
+                $query[$key] = implode(",", $value);
+            }
+        }
 
         $this->query_string = array_merge($this->query_string, $query);
 

--- a/tests/EseyeTest.php
+++ b/tests/EseyeTest.php
@@ -202,10 +202,16 @@ class EseyeTest extends PHPUnit_Framework_TestCase
     public function testEseyeGetAndSetQueryString()
     {
 
-        $object = $this->esi->setQueryString(['foo' => 'bar']);
+        $object = $this->esi->setQueryString([
+            'foo' => 'bar',
+            'foobar' => ['foo', 'bar'],
+        ]);
 
         $this->assertInstanceOf(Eseye::class, $object);
-        $this->assertEquals(['foo' => 'bar'], $this->esi->getQueryString());
+        $this->assertEquals([
+            'foo' => 'bar',
+            'foobar' => ['foo,bar'],
+        ], $this->esi->getQueryString());
     }
 
     public function testEseyeGetAndSetBody()

--- a/tests/EseyeTest.php
+++ b/tests/EseyeTest.php
@@ -210,7 +210,7 @@ class EseyeTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Eseye::class, $object);
         $this->assertEquals([
             'foo' => 'bar',
-            'foobar' => ['foo,bar'],
+            'foobar' => ['foo', 'bar'],
         ], $this->esi->getQueryString());
     }
 

--- a/tests/EseyeTest.php
+++ b/tests/EseyeTest.php
@@ -210,7 +210,7 @@ class EseyeTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Eseye::class, $object);
         $this->assertEquals([
             'foo' => 'bar',
-            'foobar' => ['foo', 'bar'],
+            'foobar' => 'foo,bar',
         ], $this->esi->getQueryString());
     }
 


### PR DESCRIPTION
This allows array parameters for ESI calls to be set as nested arrays via setQueryString().

Example:
```
$esi = new \Seat\Eseye\Eseye;

$query = [
    'categories' => [
        'region',
        'inventory_type',
    ],
    'search' => 'Providence',
];

$esi->setQueryString($query)->invoke('get', '/search/')
```