### PR TITLE
Add setRefreshToken() methods to Eseye and EsiAuthentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 /logs/
 /cache/
 /build/
+.DS_Store

--- a/src/Containers/EsiAuthentication.php
+++ b/src/Containers/EsiAuthentication.php
@@ -46,4 +46,10 @@ class EsiAuthentication extends AbstractArrayAccess
         'scopes'        => [],
     ];
 
+    public function setRefreshToken(String $refreshToken)
+    {
+        $this->data['refresh_token'] = $refreshToken;
+        return $this;
+    }
+
 }

--- a/src/Containers/EsiAuthentication.php
+++ b/src/Containers/EsiAuthentication.php
@@ -46,7 +46,7 @@ class EsiAuthentication extends AbstractArrayAccess
         'scopes'        => [],
     ];
 
-    public function setRefreshToken(String $refreshToken)
+    public function setRefreshToken(String $refreshToken): self
     {
         $this->data['refresh_token'] = $refreshToken;
         return $this;

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -168,6 +168,12 @@ class Eseye
         return $this;
     }
 
+    public function setRefreshToken(String $refreshToken)
+    {
+        $this->authentication = $this->authentication->setRefreshToken($refreshToken);
+        return $this;
+    }
+
     /**
      * @param \Seat\Eseye\Fetchers\FetcherInterface $fetcher
      */

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -168,7 +168,7 @@ class Eseye
         return $this;
     }
 
-    public function setRefreshToken(String $refreshToken)
+    public function setRefreshToken(String $refreshToken): self
     {
         $this->authentication = $this->authentication->setRefreshToken($refreshToken);
         return $this;

--- a/tests/Containers/EsiAuthenticationTest.php
+++ b/tests/Containers/EsiAuthenticationTest.php
@@ -127,4 +127,13 @@ class EsiAuthenticationTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    public function testEsiAuthenticationContainerSetRefreshToken()
+    {
+
+        $authentication = new EsiAuthentication;
+        $authentication->setRefreshToken('test');
+
+        $this->assertEquals('test', $authentication->refresh_token);
+    }
+
 }

--- a/tests/Containers/EsiAuthenticationTest.php
+++ b/tests/Containers/EsiAuthenticationTest.php
@@ -131,9 +131,9 @@ class EsiAuthenticationTest extends PHPUnit_Framework_TestCase
     {
 
         $authentication = new EsiAuthentication;
-        $authentication->setRefreshToken('test');
+        $authentication->setRefreshToken('REFRESH_TOKEN');
 
-        $this->assertEquals('test', $authentication->refresh_token);
+        $this->assertEquals('REFRESH_TOKEN', $authentication->refresh_token);
     }
 
 }

--- a/tests/EseyeTest.php
+++ b/tests/EseyeTest.php
@@ -333,4 +333,22 @@ class EseyeTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
+    public function testEseyeSetRefreshToken()
+    {
+
+        $authentication = new EsiAuthentication([
+            'client_id'     => 'SSO_CLIENT_ID',
+            'secret'        => 'SSO_SECRET',
+            'access_token'  => 'ACCESS_TOKEN',
+            'refresh_token' => 'CHARACTER_REFRESH_TOKEN',
+            'token_expires' => '1970-01-01 00:00:00',
+            'scopes'        => ['public'],
+        ]);
+        $this->esi->setAuthentication($authentication);
+
+        $this->esi->setRefreshToken('ALTERNATE_REFRESH_TOKEN');
+
+        $this->assertEquals('ALTERNATE_REFRESH_TOKEN', $this->esi->getAuthentication()->refresh_token);
+    }
+
 }


### PR DESCRIPTION
This adds the ability to change the refresh token an Eseye instance uses on the fly without forcing a mostly redundant new definition and instantiation of an EsiAuthentication container, or the creation of a new Eseye instance altogether.

The idea behind this is to make working with different refresh tokens a lot easier in any application working with ESI and multiple refresh tokens such as alliance/coalition web services and auth systems.

I also updated .gitignore to include [.DS_Store files](https://en.wikipedia.org/wiki/.DS_Store) because I nearly committed a whole bunch of them earlier on.