### PR TITLE
Add loaded_from_cache flag to EsiResponse

### DIFF
--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -228,8 +228,8 @@ class EsiResponse extends ArrayObject
     /**
      * @return bool
      */
-    public function setLoadedFromCache($loaded_from_cache): bool
+    public function setLoadedFromCache(): bool
     {
-        return $this->loaded_from_cache = $loaded_from_cache;
+        return $this->loaded_from_cache = true;
     }
 }

--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -80,7 +80,7 @@ class EsiResponse extends ArrayObject
     /**
      * @var bool
      */
-    protected $from_cache;
+    protected $loaded_from_cache = false;
 
     /**
      * EsiResponse constructor.
@@ -228,8 +228,8 @@ class EsiResponse extends ArrayObject
     /**
      * @return bool
      */
-    public function setFromCache($from_cache): bool
+    public function setLoadedFromCache($loaded_from_cache): bool
     {
-        return $this->from_cache = $from_cache;
+        return $this->loaded_from_cache = $loaded_from_cache;
     }
 }

--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -78,6 +78,11 @@ class EsiResponse extends ArrayObject
     protected $optional_return;
 
     /**
+     * @var bool
+     */
+    protected $from_cache;
+
+    /**
      * EsiResponse constructor.
      *
      * @param string $data
@@ -218,5 +223,13 @@ class EsiResponse extends ArrayObject
     {
 
         return $this->response_code;
+    }
+
+    /**
+     * @return bool
+     */
+    public function setFromCache($from_cache): bool
+    {
+        return $this->from_cache = $from_cache;
     }
 }

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -244,7 +244,11 @@ class Eseye
 
         // Cache the response if it was a get and is not already expired
         if (in_array(strtolower($method), $this->cachable_verb) && ! $result->expired())
-            $this->getCache()->set($uri->getPath(), $uri->getQuery(), $result);
+            $cachedResult = $result;
+            $cachedResult->setFromCache(true);
+            $this->getCache()->set($uri->getPath(), $uri->getQuery(), $cachedResult);
+
+        $result->setFromCache(false);
 
         // In preperation for the next request, perform some
         // self cleanups of this objects request data such as

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -237,7 +237,8 @@ class Eseye
         if (in_array(strtolower($method), $this->cachable_verb) &&
             $cached = $this->getCache()->get($uri->getPath(), $uri->getQuery())
         ) {
-            $cached->setLoadedFromCache(true);
+            $cached->setLoadedFromCache();
+
             return $cached;
         }
 

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -236,19 +236,17 @@ class Eseye
         // Check if there is a cached response we can return
         if (in_array(strtolower($method), $this->cachable_verb) &&
             $cached = $this->getCache()->get($uri->getPath(), $uri->getQuery())
-        )
+        ) {
+            $cached->setLoadedFromCache(true);
             return $cached;
+        }
 
         // Call ESI itself and get the EsiResponse
         $result = $this->rawFetch($method, $uri, $this->getBody());
 
         // Cache the response if it was a get and is not already expired
         if (in_array(strtolower($method), $this->cachable_verb) && ! $result->expired())
-            $cachedResult = $result;
-            $cachedResult->setFromCache(true);
-            $this->getCache()->set($uri->getPath(), $uri->getQuery(), $cachedResult);
-
-        $result->setFromCache(false);
+            $this->getCache()->set($uri->getPath(), $uri->getQuery(), $result);
 
         // In preperation for the next request, perform some
         // self cleanups of this objects request data such as


### PR DESCRIPTION
Addresses #22.

The approach I took sets the flag right before the EsiResponse is returned in Eseye::invoke() and should work regardless of the cache implementation used.

I would include tests for this but I don't know where to start on that front. That being said, I've tested it by hand and it seems to work well enough.