### PR TITLE
feat(core): Allow Eseye to use alternative SSO endpoint

### DIFF
--- a/src/Containers/EsiConfiguration.php
+++ b/src/Containers/EsiConfiguration.php
@@ -43,10 +43,17 @@ class EsiConfiguration extends AbstractArrayAccess
      */
     protected $data = [
         'http_user_agent'            => 'Eseye Default Library',
+
+        // Esi
         'datasource'                 => 'tranquility',
         'esi_scheme'                 => 'https',
         'esi_host'                   => 'esi.evetech.net',
         'esi_port'                   => 443,
+
+        // Eve Online SSO
+        'sso_scheme'                 => 'https',
+        'sso_host'                   => 'login.eveonline.com',
+        'sso_port'                   => 443,
 
         // Fetcher
         'fetcher'                    => GuzzleFetcher::class,

--- a/src/Fetchers/GuzzleFetcher.php
+++ b/src/Fetchers/GuzzleFetcher.php
@@ -59,7 +59,7 @@ class GuzzleFetcher implements FetcherInterface
     /**
      * @var string
      */
-    protected $sso_base = 'https://login.eveonline.com/oauth';
+    protected $sso_base;
 
     /**
      * EseyeFetcher constructor.
@@ -75,6 +75,10 @@ class GuzzleFetcher implements FetcherInterface
 
         // Setup the logger
         $this->logger = Configuration::getInstance()->getLogger();
+        $this->sso_base = sprintf('%s://%s:%d/oauth',
+            Configuration::getInstance()->sso_scheme,
+            Configuration::getInstance()->sso_host,
+            Configuration::getInstance()->sso_port);
     }
 
     /**


### PR DESCRIPTION
CCP is working hard to make Tranquility ESI compliant together with
Serenity reborn.

According to CCP Bartender, they're targetting a
maximum of 48 hours delay between Tranquility updates and Serenity
updates.

In despite that we already allow alternative ESI and source
endpoints, we're still use hardcoded SSO endpoint which is not possible
with Serenity Architecture.

Base ESI would be https://esi.evepc.163.com
and the OAuth path should be https://login.evepc.163.com (according to
actual documentation)

Closes eveseat/seat#550