### PR TITLE
feat(auth): switch to oauth v2 endpoints (JWT support)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,10 @@
     "type": "library",
     "require": {
         "php": ">= 7.2",
+        "ext-gmp": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-openssl": "*",
         "guzzlehttp/guzzle": "^6.2",
         "nesbot/carbon": "^2.0",
         "monolog/monolog": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,11 @@
         "guzzlehttp/guzzle": "^6.2",
         "nesbot/carbon": "^2.0",
         "monolog/monolog": "^2.0",
-        "predis/predis": "^1.1"
+        "predis/predis": "^1.1",
+        "web-token/jwt-easy": "^2.1",
+        "web-token/jwt-signature-algorithm-hmac": "^2.1",
+        "web-token/jwt-signature-algorithm-rsa": "^2.1",
+        "web-token/jwt-signature-algorithm-ecdsa": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Checker/Claim/AzpChecker.php
+++ b/src/Checker/Claim/AzpChecker.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eseye\Checker\Claim;
+
+use Jose\Component\Checker\ClaimChecker;
+use Jose\Component\Checker\InvalidClaimException;
+
+/**
+ * Class AzpChecker.
+ *
+ * @package Seat\Web\Extentions\Socialite\EveOnline\Checker\Claim
+ */
+class AzpChecker implements ClaimChecker
+{
+    private const NAME = 'azp';
+
+    /**
+     * @var string
+     */
+    private $client_id;
+
+    /**
+     * AzpChecker constructor.
+     *
+     * @param string $client_id
+     */
+    public function __construct(string $client_id)
+    {
+        $this->client_id = $client_id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkClaim($value): void
+    {
+        if (! is_string($value))
+            throw new InvalidClaimException('"azp" must be a string.', self::NAME, $value);
+
+        if ($value !== $this->client_id)
+            throw new InvalidClaimException('"azp" must match the originating application.', self::NAME, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportedClaim(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Checker/Claim/NameChecker.php
+++ b/src/Checker/Claim/NameChecker.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eseye\Checker\Claim;
+
+use Jose\Component\Checker\ClaimChecker;
+use Jose\Component\Checker\InvalidClaimException;
+
+/**
+ * Class NameChecker.
+ *
+ * @package Seat\Web\Extentions\Socialite\EveOnline\Checker\Claim
+ */
+class NameChecker implements ClaimChecker
+{
+    private const NAME = 'name';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkClaim($value): void
+    {
+        if (! is_string($value))
+            throw new InvalidClaimException('"name" must be a string.', self::NAME, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportedClaim(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Checker/Claim/OwnerChecker.php
+++ b/src/Checker/Claim/OwnerChecker.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eseye\Checker\Claim;
+
+use Jose\Component\Checker\ClaimChecker;
+use Jose\Component\Checker\InvalidClaimException;
+
+/**
+ * Class OwnerChecker.
+ *
+ * @package Seat\Web\Extentions\Socialite\EveOnline\Checker\Claim
+ */
+class OwnerChecker implements ClaimChecker
+{
+    private const NAME = 'owner';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkClaim($value): void
+    {
+        if (! is_string($value))
+            throw new InvalidClaimException('"owner" must be a string.', self::NAME, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportedClaim(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Checker/Claim/SubEveCharacterChecker.php
+++ b/src/Checker/Claim/SubEveCharacterChecker.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eseye\Checker\Claim;
+
+use Jose\Component\Checker\ClaimChecker;
+use Jose\Component\Checker\InvalidClaimException;
+
+/**
+ * Class SubEveCharacterChecker.
+ *
+ * @package Seat\Services\Socialite\EveOnline\Checker\Claim
+ */
+class SubEveCharacterChecker implements ClaimChecker
+{
+    private const NAME = 'sub';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkClaim($value): void
+    {
+        if (! is_string($value))
+            throw new InvalidClaimException('"sub" must be a string.', self::NAME, $value);
+
+        if (preg_match('/^CHARACTER:EVE:[0-9]+$/', $value) !== 1)
+            throw new InvalidClaimException('"sub" must be of the form CHARACTER:EVE:{character_id}', self::NAME, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportedClaim(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Checker/Header/TypeChecker.php
+++ b/src/Checker/Header/TypeChecker.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018, 2019, 2020  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Eseye\Checker\Header;
+
+use Jose\Component\Checker\HeaderChecker;
+use Jose\Component\Checker\InvalidHeaderException;
+
+/**
+ * Class TypeChecker.
+ *
+ * @package Seat\Web\Extentions\Socialite\EveOnline\Checker
+ */
+final class TypeChecker implements HeaderChecker
+{
+    private const HEADER_NAME = 'typ';
+
+    /**
+     * @var bool
+     */
+    private $protected_header = true;
+
+    /**
+     * @var string[]
+     */
+    private $supported_types;
+
+    /**
+     * TypeChecker constructor.
+     *
+     * @param string[] $supported_types
+     * @param bool $protected_header
+     */
+    public function __construct(array $supported_types, bool $protected_header = true)
+    {
+        $this->supported_types = $supported_types;
+        $this->protected_header = $protected_header;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkHeader($value): void
+    {
+        if (! is_string($value))
+            throw new InvalidHeaderException('"typ" must be a string.', self::HEADER_NAME, $value);
+
+        if (! in_array($value, $this->supported_types, true))
+            throw new InvalidHeaderException('Unsupported type.', self::HEADER_NAME, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportedHeader(): string
+    {
+        return self::HEADER_NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function protectedHeaderOnly(): bool
+    {
+        return $this->protected_header;
+    }
+}

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -169,7 +169,7 @@ class Eseye
      *
      * @return \Seat\Eseye\Eseye
      */
-    public function setRefreshToken(String $refreshToken): self
+    public function setRefreshToken(string $refreshToken): self
     {
 
         $this->authentication = $this->authentication->setRefreshToken($refreshToken);

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -45,7 +45,7 @@ class Eseye
     /**
      * The Eseye Version.
      */
-    const VERSION = '2.0.0';
+    const VERSION = '2.1.0';
 
     /**
      * @var \Seat\Eseye\Containers\EsiAuthentication

--- a/src/Fetchers/GuzzleFetcher.php
+++ b/src/Fetchers/GuzzleFetcher.php
@@ -165,17 +165,22 @@ class GuzzleFetcher implements FetcherInterface
     {
 
         // Make the post request for a new access_token
-        $response = $this->httpRequest('post', $this->sso_base . '/token',
+        $response = $this->getClient()->post($this->sso_base . '/token',
             [
-                'Content-Type' => 'application/x-form-urlencoded',
-                'Authorization' => 'Basic ' . base64_encode(
+                'form_params' => [
+                    'grant_type' => 'refresh_token',
+                    'refresh_token' => $this->authentication->refresh_token,
+                ],
+                'headers' => [
+                    'Authorization' => 'Basic ' . base64_encode(
                         $this->authentication->client_id . ':' . $this->authentication->secret),
-            ],
-            [
-                'grant_type' => 'refresh_token',
-                'refresh_token' => $this->authentication->refresh_token,
+                    'User-Agent'   => 'Eseye/' . Eseye::VERSION . '/' .
+                        Configuration::getInstance()->http_user_agent,
+                ],
             ]
         );
+
+        $response = json_decode($response->getBody()->getContents());
 
         // Get the current EsiAuth container
         $authentication = $this->getAuthentication();

--- a/src/Fetchers/GuzzleFetcher.php
+++ b/src/Fetchers/GuzzleFetcher.php
@@ -75,7 +75,7 @@ class GuzzleFetcher implements FetcherInterface
 
         // Setup the logger
         $this->logger = Configuration::getInstance()->getLogger();
-        $this->sso_base = sprintf('%s://%s:%d/oauth',
+        $this->sso_base = sprintf('%s://%s:%d/v2/oauth',
             Configuration::getInstance()->sso_scheme,
             Configuration::getInstance()->sso_host,
             Configuration::getInstance()->sso_port);
@@ -165,11 +165,15 @@ class GuzzleFetcher implements FetcherInterface
     {
 
         // Make the post request for a new access_token
-        $response = $this->httpRequest('post',
-            $this->sso_base . '/token/?grant_type=refresh_token&refresh_token=' .
-            $this->authentication->refresh_token, [
+        $response = $this->httpRequest('post', $this->sso_base . '/token',
+            [
+                'Content-Type' => 'application/x-form-urlencoded',
                 'Authorization' => 'Basic ' . base64_encode(
                         $this->authentication->client_id . ':' . $this->authentication->secret),
+            ],
+            [
+                'grant_type' => 'refresh_token',
+                'refresh_token' => $this->authentication->refresh_token,
             ]
         );
 

--- a/tests/Fetchers/GuzzleFetcherTest.php
+++ b/tests/Fetchers/GuzzleFetcherTest.php
@@ -24,6 +24,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Jose\Component\Core\JWK;
+use Jose\Easy\Build;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Containers\EsiAuthentication;
 use Seat\Eseye\Containers\EsiResponse;
@@ -199,11 +201,32 @@ class GuzzleFetcherTest extends PHPUnit_Framework_TestCase
     public function testGuzzleCallingWithAuthentication()
     {
 
+        // init a JWK set
+        $jwk = $this->getJwkSet();
+
+        // generate a JWS Token mocking standard CCP format
+        $jws = $this->getJwsToken($jwk);
+
         $mock = new MockHandler([
             // RefreshToken response
             new Response(200, ['X-Foo' => 'Bar'], json_encode([
-                'access_token' => 'foo', 'expires_in' => 1200, 'refresh_token' => 'bar',
+                'access_token'  => $jws,
+                'expires_in'    => 1200,
+                'token_type'    => 'Bearer',
+                'refresh_token' => 'bar',
             ])),
+            // JWKS endpoint response
+            new Response(200, [], json_encode([
+                'jwks_uri' => 'https://login.eveonline.com/oauth/jwks',
+            ])),
+            // JWK Sets response
+            new Response(200, [], json_encode([
+                'keys' => [
+                    $jwk->jsonSerialize(),
+                ],
+                'SkipUnresolvedJsonWebKeys' => true,
+            ])),
+            // ESI response
             new Response(200, ['X-Foo' => 'Bar'], json_encode(['foo' => 'var'])),
         ]);
 
@@ -265,13 +288,23 @@ class GuzzleFetcherTest extends PHPUnit_Framework_TestCase
     public function testGuzzleConstructsWithClientAndGetsAuthenticationScopes()
     {
 
+        // init a JWK Set
+        $jwk = $this->getJwkSet();
+
+        // init a JWS Token
+        $jws = $this->getJwsToken($jwk);
+
         $mock = new MockHandler([
-            // RefreshToken response
-            new Response(200, ['X-Foo' => 'Bar'], json_encode([
-                'access_token' => 'foo', 'expires_in' => 1200, 'refresh_token' => 'bar',
+            // JWK Endpoint
+            new Response(200, [], json_encode([
+                'jwks_uri' => 'https://login.eveonline.com/oauth/jwks',
             ])),
-            new Response(200, ['X-Foo' => 'Bar'], json_encode([
-                'Scopes' => 'foo bar baz',
+            // JWK Sets response
+            new Response(200, [], json_encode([
+                'keys' => [
+                    $jwk->jsonSerialize(),
+                ],
+                'SkipUnresolvedJsonWebKeys' => true,
             ])),
         ]);
 
@@ -284,7 +317,7 @@ class GuzzleFetcherTest extends PHPUnit_Framework_TestCase
         $authentication = new EsiAuthentication([
             'client_id'     => 'foo',
             'secret'        => 'bar',
-            'access_token'  => '_',
+            'access_token'  => $jws,
             'refresh_token' => 'baz',
             'token_expires' => '1970-01-01 00:00:00',
         ]);
@@ -295,5 +328,58 @@ class GuzzleFetcherTest extends PHPUnit_Framework_TestCase
         $scopes = $fetcher->getAuthenticationScopes();
 
         $this->assertEquals(['foo', 'bar', 'baz', 'public'], $scopes);
+    }
+
+    /**
+     * @return \Jose\Component\Core\JWK
+     */
+    private function getJwkSet()
+    {
+        return new JWK([
+            "p"   => "1UQV33bi2J-WJ9529sOTuXiAGCh_lcUAgRHayLbBSElC9O_kA8g2ipC0Qu58tpKdKjq2dD7_SfbESqEI0AJD7oMfP1i-Ispn31vjIb7fmnlddF2qflc9SEkWkrZPCntusTzIraxBDUwIlmdOdAI24xHHpGe-DISE4R1LYrQS0m0",
+            "kty" => "RSA",
+            "q"   => "yaEesJOxfHkeYvlo8f1NVCrCyxfzDl3_-_qDm-bpdUDjemsvolYD6AEb0GGiyjFdMJg29iCke_8nzYIuwDf2QzFS96aU0IpxLwyNsXBdOr7K53WmDj7LU4xFfR-gaOQEp-o2KZ7-1EqpPRgeI12wVpfR3Mi4TZuXlgmeyYpt_BU",
+            "d"   => "iZo3pjr-cegcZN2lk3I3qL8By-8bSO4DaZdih6BnHB-VJbhhmSky64wP34wpKe_G486C1o9IsVZ6zuhXrOJdEOIike3d0IKg6jNY24RsV-AX5hYn44Us8ePHQnhqtxf42GujloroctLkAJAlpnYg6-rWW7kAoCjrNxVIaJ4AOabIcpIQwNwqHNjWifik6WttpC_-u-4HmTLG6f-NrVqrSJkBTReRCjsSYz1GH_snBGx2SFS5XbEfvWe0g-Asu8kZPzYL7y5ahMZ3AT4qOjNA-UFkIzYW0BQjwMwTzRq_30bTDZXBLH8YbDCD6HwBhVThmX4k6AjWr4yG7-uJfvTAgQ",
+            "e"   => "AQAB",
+            "use" => "sig",
+            "kid" => "JWK Signature Mock",
+            "qi"  => "baoXJXUnqalu6CMibn1aILUhfDbjW_lVVk-b9ZAK7ZVi8vEKDpvFWTeB-R-kZMaQcYZKSOZshfXSOd8p_hpCY7nL5XuQPndR2jg23vnsddppT8dwOsiOPX1gQufwrtTQX9oibcDX1P5z942esrbHW5ttEkgM4i8Xo5G7tkKed8k",
+            "dp"  => "d2kK8jdn5rDca3Blnd9-HFA7MMukPGC02o_7t3yUlnvm0KxtOCznVQiW1g8gpz1KYLXFKSuI14oi-EJYY9eQ38BtQ5PVyjcYl_ikIWX1X1HrINe9OcZxGsNJr1YCxbS9EuIc3xlexyo2eLhZNh1zTArNhOFNiUa9_Cnh5t861rU",
+            "alg" => "RS256",
+            "dq"  => "rUXJGfXSkSWE94leppcH3UziGaZ7Od2OHv0qHNBT0G_zDUEPrnI86SQKwwkk3J2PeDNXCC0FLYoYqoM1qfptp1C7_BcrzAstOUGQguwNMm7D8CUqjxNnqGTjUqPbNki9t4-O_DWmyMlgpyASxlG9OK0_rHzR5d_QZR_fVVOhMQ",
+            "n"  => "p_iuj0pLDqQsdtXl6cJ8Gqhtm8F5dUSbmNPYoNbB_uM0oQrBBxvKPH7GzDduFMtS6LfloH3hGryTum-lxU1yQ4PjaN3IEdrGpqS6_OWtqZ6mRWrDDNdgWmkFtq5kPwfR2EXdcygWREJ7w1376WWx9l3tVu6zygfCghTTUhVT65fjmnNUR6zWJn15pxTjnQ-zphKlgvWnCDwJEW9UFXK025ztMQFn8rkTxJV9O3Qu3QS-VRjVicPhV7oOMs2YhiqUAmnzu285nKTaG6N_83NIZ5W2N06JfMt6epvTiC-st2joQp4FCsiVPEEQ6wjZJTA7cpdmIoc05X7gMKdipxeO8Q"
+        ]);
+    }
+
+    /**
+     * @param \Jose\Component\Core\JWK $jwk
+     * @return string
+     */
+    private function getJwsToken(JWK $jwk): string
+    {
+        $time = time();
+
+        return Build::jws()
+            ->exp($time + 1200)
+            ->alg('RS256')
+            ->payload([
+                'scp' => [
+                    "foo",
+                    "bar",
+                    "baz",
+                    "public",
+                ],
+                "jti" => "7f64ea9f-ee6e-4c4a-9486-d668e8c79f25",
+                "kid" => "JWT-Signature-Key",
+                "sub" => "CHARACTER:EVE:90795931",
+                "azp" => "foo",
+                "name" => "Warlof Tutsimo",
+                "owner" => "svnSjVa1uGYyp/ZL3mfkIwkJYzQ=",
+                "exp"   => $time + 3600,
+                "iss" => "login.eveonline.com",
+            ])
+            ->header('typ', 'JWT')
+            ->header('kid', 'JWT-Signature-Key')
+            ->sign($jwk);
     }
 }


### PR DESCRIPTION
This change switch oauth endpoints to v2 which introduce JWT support.
In order to add full support, I would also introduce web-token framework library which will be used to :
 - parse received token
 - verify the token
 - use the original expires timestamp (actually, we may have a delay between original expires timestamp and computed one since we add provided duration to actual server date/time (meaning - compute start when response has been fully interpreted)

Complete implementation sample https://github.com/eveseat/services/blob/4.0.x/src/Socialite/EveOnline/Provider.php#L156-L187

Unserialized JWT payload sample :

```
{
  "scp": [
    "esi-alliances.read_contacts.v1",
    "esi-assets.read_assets.v1",
    "esi-assets.read_corporation_assets.v1",
    "esi-bookmarks.read_character_bookmarks.v1",
    "esi-bookmarks.read_corporation_bookmarks.v1",
    "esi-calendar.read_calendar_events.v1",
    "esi-characters.read_agents_research.v1",
    "esi-characters.read_blueprints.v1",
    "esi-characters.read_chat_channels.v1",
    "esi-characters.read_contacts.v1",
    "esi-characters.read_corporation_roles.v1",
    "esi-characters.read_fatigue.v1",
    "esi-characters.read_fw_stats.v1",
    "esi-characters.read_loyalty.v1",
    "esi-characters.read_medals.v1",
    "esi-characters.read_notifications.v1",
    "esi-characters.read_opportunities.v1",
    "esi-characters.read_standings.v1",
    "esi-characters.read_titles.v1",
    "esi-characterstats.read.v1",
    "esi-clones.read_clones.v1",
    "esi-clones.read_implants.v1",
    "esi-contracts.read_character_contracts.v1",
    "esi-contracts.read_corporation_contracts.v1",
    "esi-corporations.read_blueprints.v1",
    "esi-corporations.read_contacts.v1",
    "esi-corporations.read_container_logs.v1",
    "esi-corporations.read_corporation_membership.v1",
    "esi-corporations.read_divisions.v1",
    "esi-corporations.read_facilities.v1",
    "esi-corporations.read_fw_stats.v1",
    "esi-corporations.read_medals.v1",
    "esi-corporations.read_standings.v1",
    "esi-corporations.read_starbases.v1",
    "esi-corporations.read_structures.v1",
    "esi-corporations.read_titles.v1",
    "esi-corporations.track_members.v1",
    "esi-fittings.read_fittings.v1",
    "esi-fleets.read_fleet.v1",
    "esi-industry.read_character_jobs.v1",
    "esi-industry.read_character_mining.v1",
    "esi-industry.read_corporation_jobs.v1",
    "esi-industry.read_corporation_mining.v1",
    "esi-killmails.read_corporation_killmails.v1",
    "esi-killmails.read_killmails.v1",
    "esi-location.read_location.v1",
    "esi-location.read_online.v1",
    "esi-location.read_ship_type.v1",
    "esi-mail.read_mail.v1",
    "esi-markets.read_character_orders.v1",
    "esi-markets.read_corporation_orders.v1",
    "esi-markets.structure_markets.v1",
    "esi-planets.manage_planets.v1",
    "esi-planets.read_customs_offices.v1",
    "esi-search.search_structures.v1",
    "esi-skills.read_skillqueue.v1",
    "esi-skills.read_skills.v1",
    "esi-ui.open_window.v1",
    "esi-universe.read_structures.v1",
    "esi-wallet.read_character_wallet.v1",
    "esi-wallet.read_corporation_wallets.v1"
  ],
  "jti": "2716ea39-069e-4056-960c-5c198a5e0c58",
  "kid": "JWT-Signature-Key",
  "sub": "CHARACTER:EVE:93519362",
  "azp": "1dfab55b31de4b6fba1cc93dc33f9d0e",
  "name": "Sireinn",
  "owner": "2+bErVUAA72YoqUQRGiUMD94siA=",
  "exp": 1578150212,
  "iss": "login.eveonline.com"
}
```

`exp` field contains the exact token expiration timestamp

Doing so mean new dependencies.

# PHP Extensions
- GMP
- MBSTRING

# Libraries
- web-token/jwt-easy
- web-token/jwt-signature-algorithm-hmac
- web-token/jwt-signature-algorithm-rsa
- web-token/jwt-signature-algorithm-ecdsa


The easy implementation of web-token library is really neat by the way - [official documentation](https://web-token.spomky-labs.com/easy#jws-creation-and-verification)