### PR TITLE
Fix multiple cache issues

### DIFF
--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -43,7 +43,7 @@ interface CacheInterface
      * @param string $uri
      * @param string $query
      *
-     * @return mixed
+     * @return \Seat\Eseye\Containers\EsiResponse|bool
      */
     public function get(string $uri, string $query = '');
 

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -164,7 +164,7 @@ class FileCache implements CacheInterface
      * @param string $uri
      * @param string $query
      *
-     * @return mixed
+     * @return \Seat\Eseye\Containers\EsiResponse|bool
      */
     public function get(string $uri, string $query = '')
     {
@@ -177,17 +177,17 @@ class FileCache implements CacheInterface
             return false;
 
         // Get the data from the file and unserialize it
-        $file = unserialize(file_get_contents($cache_file_path));
+        $data = unserialize(file_get_contents($cache_file_path));
 
         // If the cached entry is expired and does not have any ETag, remove it.
-        if ($file->expired() && ! $file->hasHeader('ETag')) {
+        if ($data->expired() && ! $data->hasHeader('ETag')) {
 
             $this->forget($uri, $query);
 
             return false;
         }
 
-        return $file;
+        return $data;
     }
 
     /**

--- a/src/Cache/MemcachedCache.php
+++ b/src/Cache/MemcachedCache.php
@@ -122,7 +122,7 @@ class MemcachedCache implements CacheInterface
      * @param string $uri
      * @param string $query
      *
-     * @return mixed
+     * @return \Seat\Eseye\Containers\EsiResponse|bool
      */
     public function get(string $uri, string $query = '')
     {

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -46,7 +46,7 @@ class NullCache implements CacheInterface
      * @param string $uri
      * @param string $query
      *
-     * @return mixed
+     * @return \Seat\Eseye\Containers\EsiResponse|bool
      */
     public function get(string $uri, string $query = '')
     {

--- a/src/Cache/RedisCache.php
+++ b/src/Cache/RedisCache.php
@@ -98,7 +98,7 @@ class RedisCache implements CacheInterface
      * @param string $uri
      * @param string $query
      *
-     * @return mixed
+     * @return \Seat\Eseye\Containers\EsiResponse|bool
      */
     public function get(string $uri, string $query = '')
     {

--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -309,7 +309,7 @@ class EsiResponse extends ArrayObject
             $this->response_code,
             $this->error_message,
             $this->optional_return,
-            $this->cached_load,
+            $this->cached_load
         ) = unserialize($data);
 
         // rebuild array with decoded value

--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -274,4 +274,48 @@ class EsiResponse extends ArrayObject
 
         return null;
     }
+
+    /**
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize([
+            $this->raw,
+            $this->headers,
+            $this->raw_headers,
+            $this->error_limit,
+            $this->pages,
+            $this->expires_at,
+            $this->response_code,
+            $this->error_message,
+            $this->optional_return,
+            $this->cached_load,
+        ]);
+    }
+
+    /**
+     * @param string $data
+     */
+    public function unserialize($data)
+    {
+        list(
+            $this->raw,
+            $this->headers,
+            $this->raw_headers,
+            $this->error_limit,
+            $this->pages,
+            $this->expires_at,
+            $this->response_code,
+            $this->error_message,
+            $this->optional_return,
+            $this->cached_load,
+        ) = unserialize($data);
+
+        // rebuild array with decoded value
+        $this->exchangeArray(json_decode($this->raw));
+
+        // update flags
+        $this->setFlags(self::ARRAY_AS_PROPS);
+    }
 }

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -237,8 +237,8 @@ class Eseye
             $cached = $this->getCache()->get($uri->getPath(), $uri->getQuery())
         ) {
 
-            // Mark the response as one that was loaded from the cache in case no ETag exists
-            if (! $cached->hasHeader('ETag'))
+            // In case the cached entry is still valid, mark content as being loaded from cache.
+            if (! $cached->expired())
                 $cached->setIsCachedLoad();
 
             // Handling ETag marked response specifically (ignoring the expired time)


### PR DESCRIPTION
Ensure the ResponseContainer is serializable (current version is not, making the cache unusable since methods will always return false)

Also make sure non expired content will be properly served from cache without needing a recall to ESI (currection version is only marking ETag content as cached :/)