### PR TITLE
feat: improve etag management by updating expires date

### DIFF
--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -276,6 +276,20 @@ class EsiResponse extends ArrayObject
     }
 
     /**
+     * @param \Carbon\Carbon $date
+     */
+    public function setExpires(Carbon $date)
+    {
+        // turn headers into case insensitive array
+        $key_map = array_change_key_case($this->headers, CASE_LOWER);
+
+        // update expires header with provided date
+        $key_map['expires'] = $date->toRfc7231String();
+        $this->expires_at = strlen($key_map['expires']) > 2 ? $key_map['expires'] : 'now';
+        $this->headers = $key_map;
+    }
+
+    /**
      * @return string
      */
     public function serialize()

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -247,8 +247,16 @@ class Eseye
 
                 $result = $this->rawFetch($method, $uri, $this->getBody(), ['If-None-Match' => $cached->getHeader('ETag')]);
 
-                if ($result->getErrorCode() == 304)
+                if ($result->getErrorCode() == 304) {
+
+                    // update expires header with newly provided value
+                    $cached->setExpires($result->expires());
+
+                    // store updated response in cache to renew internal cache duration
+                    $this->getCache()->set($uri->getPath(), $uri->getQuery(), $cached);
+
                     $cached->setIsCachedLoad();
+                }
             }
 
             // In case the result is effectively retrieved from cache,
@@ -457,7 +465,7 @@ class Eseye
      * @param array  $body
      * @param array  $headers
      *
-     * @return mixed
+     * @return \Seat\Eseye\Containers\EsiResponse
      * @throws \Seat\Eseye\Exceptions\InvalidAuthenticationException
      * @throws \Seat\Eseye\Exceptions\RequestFailedException
      * @throws \Seat\Eseye\Exceptions\InvalidContainerDataException

--- a/src/Fetchers/GuzzleFetcher.php
+++ b/src/Fetchers/GuzzleFetcher.php
@@ -94,7 +94,7 @@ class GuzzleFetcher implements FetcherInterface
      * @param array  $body
      * @param array  $headers
      *
-     * @return mixed|\Seat\Eseye\Containers\EsiResponse
+     * @return \Seat\Eseye\Containers\EsiResponse
      * @throws \Seat\Eseye\Exceptions\InvalidAuthenticationException
      * @throws \Seat\Eseye\Exceptions\RequestFailedException
      * @throws \Seat\Eseye\Exceptions\InvalidContainerDataException

--- a/tests/Containers/EsiResponseTest.php
+++ b/tests/Containers/EsiResponseTest.php
@@ -183,4 +183,15 @@ class EsiResponseTest extends PHPUnit_Framework_TestCase
         $this->esi_response->setIsCachedload();
         $this->assertTrue($this->esi_response->isCachedLoad());
     }
+
+    public function testEsiResponseCanSetExpires()
+    {
+        $old_expires = $this->esi_response->expires();
+        $new_expires = carbon()->addHour();
+
+        $this->esi_response->setExpires($new_expires);
+
+        $this->assertNotEquals($old_expires, $this->esi_response->expires());
+        $this->assertNotEquals($old_expires->toRfc7231String(), $this->esi_response->getHeader('expires'));
+    }
 }

--- a/tests/EseyeTest.php
+++ b/tests/EseyeTest.php
@@ -301,7 +301,7 @@ class EseyeTest extends PHPUnit_Framework_TestCase
     {
         $mock = new MockHandler([
             new Response(200, [
-                'Expires' => carbon()->addSeconds(10)->toRfc7231String(),
+                'Expires' => carbon()->addSeconds(3)->toRfc7231String(),
                 'ETag' => 'W/"b3ef78b1064a27974cbf18270c1f126d519f7b467ba2e35ccb6f0819"',
             ], json_encode(['foo' => 'bar'])),
             new Response(304, [
@@ -312,8 +312,6 @@ class EseyeTest extends PHPUnit_Framework_TestCase
 
         $config = Configuration::getInstance();
         $config->cache = FileCache::class;
-
-        //$esi = new Eseye;
 
         $fetcher = new GuzzleFetcher;
         $fetcher->setClient(new Client([
@@ -327,7 +325,7 @@ class EseyeTest extends PHPUnit_Framework_TestCase
         $response = $this->esi->invoke('get', '/foo2');
         $this->assertFalse($response->isCachedLoad());
 
-        sleep(20);
+        sleep(5);
 
         // send a new call to trigger cache
         $response = $this->esi->invoke('get', '/foo2');


### PR DESCRIPTION
This pull request is allowing Expires header from response container to be altered.

So we can update or internal cache based on ETag result and avoid to spam ESI with requests when we already know the content have not been altered.

We're using updated Expires header from any 304 response we may receive to update cached response.