### PR TITLE
Improve response container serialization and avoid invalid string

### DIFF
--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -288,48 +288,4 @@ class EsiResponse extends ArrayObject
         $this->expires_at = strlen($key_map['expires']) > 2 ? $key_map['expires'] : 'now';
         $this->headers = $key_map;
     }
-
-    /**
-     * @return string
-     */
-    public function serialize()
-    {
-        return serialize([
-            $this->raw,
-            $this->headers,
-            $this->raw_headers,
-            $this->error_limit,
-            $this->pages,
-            $this->expires_at,
-            $this->response_code,
-            $this->error_message,
-            $this->optional_return,
-            $this->cached_load,
-        ]);
-    }
-
-    /**
-     * @param string $data
-     */
-    public function unserialize($data)
-    {
-        [
-            $this->raw,
-            $this->headers,
-            $this->raw_headers,
-            $this->error_limit,
-            $this->pages,
-            $this->expires_at,
-            $this->response_code,
-            $this->error_message,
-            $this->optional_return,
-            $this->cached_load
-        ] = unserialize($data);
-
-        // rebuild array with decoded value
-        $this->exchangeArray((object) json_decode($this->raw));
-
-        // update flags
-        $this->setFlags(self::ARRAY_AS_PROPS);
-    }
 }

--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -101,7 +101,7 @@ class EsiResponse extends ArrayObject
         $this->parseHeaders($headers);
 
         // decode and create an object from the data
-        $data = (object) json_decode($data);
+        $data = json_decode($data);
 
         // Ensure that the value for 'expires' is longer than
         // 2 characters. The shortest expected value is 'now'. If it
@@ -109,16 +109,19 @@ class EsiResponse extends ArrayObject
         $this->expires_at = strlen($expires) > 2 ? $expires : 'now';
         $this->response_code = $response_code;
 
-        // If there is an error, set that.
-        if (property_exists($data, 'error'))
-            $this->error_message = $data->error;
+        if (is_object($data)) {
 
-        // If there is an error description, set that.
-        if (property_exists($data, 'error_description'))
-            $this->error_message .= ': ' . $data->error_description;
+            // If there is an error, set that.
+            if (property_exists($data, 'error'))
+                $this->error_message = $data->error;
+
+            // If there is an error description, set that.
+            if (property_exists($data, 'error_description'))
+                $this->error_message .= ': ' . $data->error_description;
+        }
 
         // Run the parent constructor
-        parent::__construct($data, ArrayObject::ARRAY_AS_PROPS);
+        parent::__construct(is_array($data) ? (array) $data : (object) $data, ArrayObject::ARRAY_AS_PROPS);
     }
 
     /**


### PR DESCRIPTION
casting an array as an object is leading to invalid class serialization.
to avoid this state, we handle cast at the end of container building.

in case the parsed json is an object, we also track for error metadata, otherwise, we leave them empty.