### PR TITLE
provide current stable with both guzzle 6 and 7

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -6,7 +6,7 @@ enabled:
   - no_empty_comment
 
 disabled:
-  - psr12_braces
+  - laravel_braces
   - concat_without_spaces
   - phpdoc_no_package
   - no_blank_lines_after_class_opening

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^6.2|^7.0",
         "nesbot/carbon": "^2.0",
         "monolog/monolog": "^2.0",
         "predis/predis": "^1.1",
@@ -18,8 +18,9 @@
         "web-token/jwt-signature-algorithm-ecdsa": "^2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^8.0|^9.0",
         "mikey179/vfsstream": "~1",
+        "m6web/redis-mock": "^5.0",
         "codeclimate/php-test-reporter": "dev-master"
     },
     "license": "GPL-2.0",

--- a/tests/Access/CheckAccessTest.php
+++ b/tests/Access/CheckAccessTest.php
@@ -20,16 +20,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Access\CheckAccess;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Log\NullLogger;
 
-class CheckAccessTest extends PHPUnit_Framework_TestCase
+class CheckAccessTest extends TestCase
 {
 
     protected $check_access;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->check_access = new CheckAccess;

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -21,18 +21,19 @@
  */
 
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Cache\FileCache;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Exceptions\CachePathException;
 
-class FileCacheTest extends PHPUnit_Framework_TestCase
+class FileCacheTest extends TestCase
 {
 
     protected $root;
 
     protected $file_cache;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         // Set the file cache path in the config singleton

--- a/tests/Cache/HashesStringsTest.php
+++ b/tests/Cache/HashesStringsTest.php
@@ -20,9 +20,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Cache\HashesStrings;
 
-class HashesStringsTest extends PHPUnit_Framework_TestCase
+class HashesStringsTest extends TestCase
 {
 
     use HashesStrings;

--- a/tests/Cache/NullCacheTest.php
+++ b/tests/Cache/NullCacheTest.php
@@ -20,15 +20,16 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Cache\NullCache;
 use Seat\Eseye\Containers\EsiResponse;
 
-class NullCacheTest extends PHPUnit_Framework_TestCase
+class NullCacheTest extends TestCase
 {
 
     protected $null_cache;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->null_cache = new NullCache;

--- a/tests/Cache/RedisCacheTest.php
+++ b/tests/Cache/RedisCacheTest.php
@@ -20,11 +20,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use M6Web\Component\RedisMock\RedisMockFactory;
+use PHPUnit\Framework\TestCase;
 use Predis\Client;
 use Seat\Eseye\Cache\RedisCache;
 use Seat\Eseye\Containers\EsiResponse;
 
-class RedisCacheTest extends PHPUnit_Framework_TestCase
+class RedisCacheTest extends TestCase
 {
 
     /**
@@ -34,14 +36,16 @@ class RedisCacheTest extends PHPUnit_Framework_TestCase
 
     protected $esi_response_object;
 
-    public function setUp()
+    public function setUp(): void
     {
 
-        $redis = $this->createMock(Client::class);
+        $factory = new RedisMockFactory();
+        $class = $factory->getAdapterClass(Client::class, true);
+        $redis = new $class();
 
         // Set the cache
         $this->redis_cache = new RedisCache($redis);
-        $this->esi_response_object = new EsiResponse('', [], 'now', 200);
+        $this->esi_response_object = new EsiResponse('', ['ETag' => 'W/"b3ef78b1064a27974cbf18270c1f126d519f7b467ba2e35ccb6f0819"'], 'now', 200);
     }
 
     public function testRedisCacheInstantiates()
@@ -67,12 +71,16 @@ class RedisCacheTest extends PHPUnit_Framework_TestCase
     {
 
         $this->redis_cache->set('/foo', 'foo=bar', $this->esi_response_object);
+
+        $this->assertEquals($this->esi_response_object, $this->redis_cache->get('/foo', 'foo=bar'));
     }
 
     public function testRedisCacheForgetsKey()
     {
 
         $this->redis_cache->forget('/foo', 'foo=bar');
+
+        $this->assertFalse($this->redis_cache->has('/foo', 'foo=bar'));
     }
 
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -20,13 +20,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Cache\CacheInterface;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Containers\EsiConfiguration;
 use Seat\Eseye\Exceptions\InvalidContainerDataException;
 use Seat\Eseye\Log\LogInterface;
 
-class ConfigurationTest extends PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
 
     public function testConfigurationInstantiation()

--- a/tests/Containers/EsiAuthenticationTest.php
+++ b/tests/Containers/EsiAuthenticationTest.php
@@ -20,15 +20,16 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Containers\EsiAuthentication;
 use Seat\Eseye\Exceptions\InvalidContainerDataException;
 
-class EsiAuthenticationTest extends PHPUnit_Framework_TestCase
+class EsiAuthenticationTest extends TestCase
 {
 
     protected $esi_authentication;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->esi_authentication = new EsiAuthentication;

--- a/tests/Containers/EsiConfigurationTest.php
+++ b/tests/Containers/EsiConfigurationTest.php
@@ -20,18 +20,19 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Containers\EsiConfiguration;
 use Seat\Eseye\Exceptions\InvalidContainerDataException;
 
 /**
  * Class EsiConfigurationTest
  */
-class EsiConfigurationTest extends \PHPUnit_Framework_TestCase
+class EsiConfigurationTest extends TestCase
 {
 
     protected $esi_configuration;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->esi_configuration = new EsiConfiguration;

--- a/tests/Containers/EsiResponseTest.php
+++ b/tests/Containers/EsiResponseTest.php
@@ -20,16 +20,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Containers\EsiResponse;
 
-class EsiResponseTest extends PHPUnit_Framework_TestCase
+class EsiResponseTest extends TestCase
 {
 
     protected $esi_response;
 
     protected $headers;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         // Sample data to work with

--- a/tests/EseyeTest.php
+++ b/tests/EseyeTest.php
@@ -24,6 +24,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Access\CheckAccess;
 use Seat\Eseye\Cache\CacheInterface;
 use Seat\Eseye\Cache\FileCache;
@@ -40,7 +41,7 @@ use Seat\Eseye\Fetchers\GuzzleFetcher;
 use Seat\Eseye\Log\LogInterface;
 use Seat\Eseye\Log\NullLogger;
 
-class EseyeTest extends PHPUnit_Framework_TestCase
+class EseyeTest extends TestCase
 {
 
     /**
@@ -48,7 +49,7 @@ class EseyeTest extends PHPUnit_Framework_TestCase
      */
     protected $esi;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         // Remove logging
@@ -89,7 +90,9 @@ class EseyeTest extends PHPUnit_Framework_TestCase
             'secret'        => 'SSO_SECRET',
             'refresh_token' => 'CHARACTER_REFRESH_TOKEN',
         ]);
-        new Eseye($authentication);
+        $client = new Eseye($authentication);
+
+        $this->assertEquals($authentication, $client->getAuthentication());
     }
 
     public function testEseyeSetNewInvalidAuthenticationData()
@@ -116,6 +119,8 @@ class EseyeTest extends PHPUnit_Framework_TestCase
             'scopes'        => ['public'],
         ]);
         $this->esi->setAuthentication($authentication);
+
+        $this->assertEquals($authentication, $this->esi->getAuthentication());
     }
 
     public function testEseyeGetAuthenticationBeforeSet()

--- a/tests/Exceptions/RequestFailedExceptionTest.php
+++ b/tests/Exceptions/RequestFailedExceptionTest.php
@@ -20,10 +20,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Containers\EsiResponse;
 use Seat\Eseye\Exceptions\RequestFailedException;
 
-class RequestFailedExceptionTest extends PHPUnit_Framework_TestCase
+class RequestFailedExceptionTest extends TestCase
 {
 
     /**
@@ -31,7 +32,7 @@ class RequestFailedExceptionTest extends PHPUnit_Framework_TestCase
      */
     protected $exception;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         $this->exception = new RequestFailedException(new Exception('Foo'), new EsiResponse(

--- a/tests/Fetchers/GuzzleFetcherTest.php
+++ b/tests/Fetchers/GuzzleFetcherTest.php
@@ -26,6 +26,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Jose\Component\Core\JWK;
 use Jose\Easy\Build;
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Containers\EsiAuthentication;
 use Seat\Eseye\Containers\EsiResponse;
@@ -34,7 +35,7 @@ use Seat\Eseye\Exceptions\RequestFailedException;
 use Seat\Eseye\Fetchers\GuzzleFetcher;
 use Seat\Eseye\Log\NullLogger;
 
-class GuzzleFetcherTest extends PHPUnit_Framework_TestCase
+class GuzzleFetcherTest extends TestCase
 {
 
     /**
@@ -42,7 +43,7 @@ class GuzzleFetcherTest extends PHPUnit_Framework_TestCase
      */
     protected $fetcher;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         // Remove logging

--- a/tests/Log/FileLoggerTest.php
+++ b/tests/Log/FileLoggerTest.php
@@ -22,17 +22,18 @@
 
 use Monolog\Logger;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Log\FileLogger;
 
-class FileLoggerTest extends PHPUnit_Framework_TestCase
+class FileLoggerTest extends TestCase
 {
 
     protected $root;
 
     protected $logger;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         // Set the file cache path in the config singleton
@@ -48,7 +49,7 @@ class FileLoggerTest extends PHPUnit_Framework_TestCase
         $this->logger->log('foo');
         $logfile_content = $this->root->getChild('eseye.log')->getContent();
 
-        $this->assertContains('eseye.INFO: foo', $logfile_content);
+        $this->assertStringContainsString('eseye.INFO: foo', $logfile_content);
     }
 
     public function testFileLoggerSkipWritesLogDebugWithoutRequiredLevel()
@@ -71,7 +72,7 @@ class FileLoggerTest extends PHPUnit_Framework_TestCase
         $logger->debug('foo');
         $logfile_content = $this->root->getChild('eseye.log')->getContent();
 
-        $this->assertContains('eseye.DEBUG: foo', $logfile_content);
+        $this->assertStringContainsString('eseye.DEBUG: foo', $logfile_content);
     }
 
     public function testFileLoggerWritesLogWarning()
@@ -80,7 +81,7 @@ class FileLoggerTest extends PHPUnit_Framework_TestCase
         $this->logger->warning('foo');
         $logfile_content = $this->root->getChild('eseye.log')->getContent();
 
-        $this->assertContains('eseye.WARNING: foo', $logfile_content);
+        $this->assertStringContainsString('eseye.WARNING: foo', $logfile_content);
     }
 
     public function testFileLoggerWritesLogError()
@@ -89,7 +90,7 @@ class FileLoggerTest extends PHPUnit_Framework_TestCase
         $this->logger->error('foo');
         $logfile_content = $this->root->getChild('eseye.log')->getContent();
 
-        $this->assertContains('eseye.ERROR: foo', $logfile_content);
+        $this->assertStringContainsString('eseye.ERROR: foo', $logfile_content);
     }
 
 }

--- a/tests/Log/NullLoggerTest.php
+++ b/tests/Log/NullLoggerTest.php
@@ -20,16 +20,16 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Log\NullLogger;
 
-class NullLoggerTest extends PHPUnit_Framework_TestCase
+class NullLoggerTest extends TestCase
 {
 
     protected $logger;
 
-    public function setUp()
+    public function setUp(): void
     {
-
 
         $this->logger = new NullLogger;
     }

--- a/tests/Log/RotatingFileLoggerTest.php
+++ b/tests/Log/RotatingFileLoggerTest.php
@@ -22,10 +22,11 @@
 
 use Monolog\Logger;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Log\RotatingFileLogger;
 
-class RotatingFileLoggerTest extends PHPUnit_Framework_TestCase
+class RotatingFileLoggerTest extends TestCase
 {
 
     protected $root;
@@ -34,7 +35,7 @@ class RotatingFileLoggerTest extends PHPUnit_Framework_TestCase
 
     protected $logfile_name;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         // Set the file cache path in the config singleton
@@ -54,7 +55,7 @@ class RotatingFileLoggerTest extends PHPUnit_Framework_TestCase
         $this->logger->log('foo');
         $logfile_content = $this->root->getChild($this->logfile_name)->getContent();
 
-        $this->assertContains('eseye.INFO: foo', $logfile_content);
+        $this->assertStringContainsString('eseye.INFO: foo', $logfile_content);
     }
 
     public function testFileLoggerSkipWritesLogDebugWithoutRequiredLevel()
@@ -77,7 +78,7 @@ class RotatingFileLoggerTest extends PHPUnit_Framework_TestCase
         $logger->debug('foo');
         $logfile_content = $this->root->getChild($this->logfile_name)->getContent();
 
-        $this->assertContains('eseye.DEBUG: foo', $logfile_content);
+        $this->assertStringContainsString('eseye.DEBUG: foo', $logfile_content);
     }
 
     public function testFileLoggerWritesLogWarning()
@@ -86,7 +87,7 @@ class RotatingFileLoggerTest extends PHPUnit_Framework_TestCase
         $this->logger->warning('foo');
         $logfile_content = $this->root->getChild($this->logfile_name)->getContent();
 
-        $this->assertContains('eseye.WARNING: foo', $logfile_content);
+        $this->assertStringContainsString('eseye.WARNING: foo', $logfile_content);
     }
 
     public function testFileLoggerWritesLogError()
@@ -95,7 +96,7 @@ class RotatingFileLoggerTest extends PHPUnit_Framework_TestCase
         $this->logger->error('foo');
         $logfile_content = $this->root->getChild($this->logfile_name)->getContent();
 
-        $this->assertContains('eseye.ERROR: foo', $logfile_content);
+        $this->assertStringContainsString('eseye.ERROR: foo', $logfile_content);
     }
 
 }


### PR DESCRIPTION
allow current stable version to use either Guzzle 6 or Guzzle 7
improve a few tests which was not making any asserting
bump tests dependencies

thanks to @gordonzero 