### PR TITLE
Allow to switch cache strategy

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -119,7 +119,7 @@ class Configuration
     public function getCache(): CacheInterface
     {
 
-        if (! $this->cache)
+        if (! $this->cache || get_class($this->cache) !== $this->configuration->cache)
             $this->cache = new $this->configuration->cache;
 
         return $this->cache;


### PR DESCRIPTION
I had an issue on my ESI calls when some are in Redis cache, and another one is on File.\
The main reason of "why I split those calls into separate caches" is because some ESI calls required a huge memory load on Redis (more than 4GB).

I used this code to validate my change :
```php
		$config = Configuration::getInstance();
		$config->logfile_location = '/tmp';
		$config->file_cache_location = '/tmp';

		$config->cache = FileCache::class;
		var_dump(get_class($config->getCache()));
		echo '<hr>';
		$config->cache = RedisCache::class;
		var_dump(get_class($config->getCache()));
		die;
```
which currently gives
```txt
string(26) "Seat\Eseye\Cache\FileCache"
string(26) "Seat\Eseye\Cache\FileCache"
```

With the update, it provides
```txt
string(26) "Seat\Eseye\Cache\FileCache"
string(27) "Seat\Eseye\Cache\RedisCache"
```