### PR TITLE
Cleanup request data should be called on successful cache load, also.

### DIFF
--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -279,6 +279,8 @@ class Eseye
 
                 $this->getLogger()->debug($logging_msg);
 
+                $this->cleanupRequestData();
+
                 return $cached;
             }
         }


### PR DESCRIPTION
Please see issue: "Cache retrieval leaves body and page set for next query. Need to call cleanupRequestData() in invoke on cache good. #76"

https://github.com/eveseat/eseye/issues/76