### PR TITLE
Fix: Rare issue where the expiration timestamp is before now()

### DIFF
--- a/src/Cache/RedisCache.php
+++ b/src/Cache/RedisCache.php
@@ -78,7 +78,7 @@ class RedisCache implements CacheInterface
     {
 
         $ttl = $data->expires()->timestamp - Carbon::now('UTC')->timestamp;
-        $this->redis->setex($this->buildCacheKey($uri, $query), $ttl, serialize($data));
+        $this->redis->setex($this->buildCacheKey($uri, $query), $ttl > 0 ? $ttl : 10, serialize($data));
     }
 
     /**


### PR DESCRIPTION
Mainly due to delay between the call and the ESI or malformed header.
Also, some routes have a very little expiration delay (see `/fleets/{fleet_id}/` or `/characters/{character_id}/calendar/` routes).

A 10 seconds expiration delay looks better than no limit at all.

Error log :
```txt
==> web/log/2023-03-20-php_errors.log <==
[20/03/2023 08:24:29] Job hostname : REDACTED
[20/03/2023 08:24:29] Job batch UUID : 2c81cb6c-dd85-413d-9397-72f206065a69
[20/03/2023 08:24:29] URL: REDACTED
[20/03/2023 08:24:29] Erreur: E_UNKNOWN (0)
[20/03/2023 08:24:29] Exception: Predis\Response\ServerException
[20/03/2023 08:24:29] Message: ERR invalid expire time in setex
[20/03/2023 08:24:29] Stack trace: #0 /data/www/evemyadmin/web/vendor/predis/predis/src/Client.php(335): Predis\Client->onErrorResponse()
#1 /data/www/evemyadmin/web/vendor/predis/predis/src/Client.php(314): Predis\Client->executeCommand()
#2 /data/www/evemyadmin/web/vendor/eveseat/eseye/src/Cache/RedisCache.php(81): Predis\Client->__call()
#3 /data/www/evemyadmin/web/vendor/eveseat/eseye/src/Eseye.php(264): Seat\Eseye\Cache\RedisCache->set()
...
#10 /data/www/evemyadmin/web/class/EVEOnline/ESI/calendar/Event.php(74): EVEOnline\ESI\calendar\Event::invokeDetails()
#11 /data/www/evemyadmin/web/class/ICE_EMA/calendar/jobs/CharacterEventsJob.php(74): EVEOnline\ESI\calendar\Event::invoke()
```