### PR TITLE
FileCache: Fix parsing issue on already removed or empty file

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -175,10 +175,11 @@ class FileCache implements CacheInterface
             return false;
 
         // Get the data from the file and unserialize it
-        $data = unserialize(file_get_contents($cache_file_path));
+        $data = @unserialize(file_get_contents($cache_file_path));
 
-        // If the cached entry is expired and does not have any ETag, remove it.
-        if ($data->expired() && ! $data->hasHeader('ETag')) {
+        // If the cached entry is corrupted (not unserializable)
+        // or expired and does not have any ETag, remove it.
+        if ($data === false || ($data->expired() && ! $data->hasHeader('ETag'))) {
 
             $this->forget($uri, $query);
 


### PR DESCRIPTION
```txt
$ cat 2023-05-12-php_errors.log | grep "Call to a member function expired() on bool" | wc -l
18
$ cat 2023-05-12-php_errors.log | grep "Call to a member function expired() on bool" -A 1
[12/05/2023 14:54:17] Message: Call to a member function expired() on bool
[12/05/2023 14:55:18] Stack trace: #0 /data/www/evemyadmin/web/vendor/eveseat/eseye/src/Cache/FileCache.php(181): Seat\Eseye\Cache\FileCache->get()
--
[12/05/2023 14:55:18] Message: Call to a member function expired() on bool
[12/05/2023 14:55:18] Stack trace: #0 /data/www/evemyadmin/web/vendor/eveseat/eseye/src/Cache/FileCache.php(181): Seat\Eseye\Cache\FileCache->get()
```

I'm having this kind of error several times per day (18 times today) due to possible multiple call to the endpoint (multi threading).
Waiting for 24 hours before sending this PR for review (trying this on my instance first)