### PR TITLE
Fix: Error handling in case of return code 502

### DIFF
--- a/src/Containers/EsiResponse.php
+++ b/src/Containers/EsiResponse.php
@@ -121,6 +121,10 @@ class EsiResponse extends ArrayObject
                 $this->error_message .= ': ' . $data->error_description;
         }
 
+        // If the query failed to contact the ESI endpoint
+        if ($this->response_code === 502)
+            $this->error_message = 'Bad gateway';
+
         // Run the parent constructor
         parent::__construct(is_array($data) ? (array) $data : (object) $data, ArrayObject::ARRAY_AS_PROPS);
     }


### PR DESCRIPTION
When a query failed in return code 502 (bad gateway), the `RequestFailedException` tries to fill the `$message` variable with a `null` value which is deprecated and throw a `E_DEPRECATED` error.

```txt
$ cat eseye-*.log | grep "bad gateway" | wc -l
550

$ cat eseye-2023-05-14.log | grep "bad gateway"
[2023-05-14T13:01:54.384626+00:00] eseye.ERROR: [http 502, bad gateway] get -> https://esi.evetech.net/latest/characters/%%REDACTED%%/wallet/?datasource=tranquility [t/e: 0.06s/]
[2023-05-14T13:26:00.975542+00:00] eseye.ERROR: [http 502, bad gateway] get -> https://esi.evetech.net/latest/markets/%%REDACTED%%/history/?datasource=tranquility&type_id=%%REDACTED%% [t/e: 0.07s/]

$ cat 2023-05-14-php_errors.log | grep "13:26:00" -A 2
[14/05/2023 13:26:00] Erreur: E_DEPRECATED (8192)
[14/05/2023 13:26:00] Exception: ErrorException
[14/05/2023 13:26:00] Message: Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated
[14/05/2023 13:26:00] Stack trace: #0 [internal function]: ICE_Core\utils\handler\ErrorHandler::log()
#1 vendor/eveseat/eseye/src/Exceptions/RequestFailedException.php(61): Exception->__construct()
#2 vendor/eveseat/eseye/src/Fetchers/GuzzleFetcher.php(293): Seat\Eseye\Exceptions\RequestFailedException->__construct()

$ cat 2023-05-14-php_errors.log | grep "13:01:54" -A 2
[14/05/2023 13:01:54] Erreur: E_DEPRECATED (8192)
[14/05/2023 13:01:54] Exception: ErrorException
[14/05/2023 13:01:54] Message: Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated
[14/05/2023 13:01:54] Stack trace: #0 [internal function]: ICE_Core\utils\handler\ErrorHandler::log()
#1 vendor/eveseat/eseye/src/Exceptions/RequestFailedException.php(61): Exception->__construct()
#2 vendor/eveseat/eseye/src/Fetchers/GuzzleFetcher.php(293): Seat\Eseye\Exceptions\RequestFailedException->__construct()
```

I'm pretty sure there is a better fix but I can't help much more at this level