### PR TITLE
fix iss claims for eseye 3.0

### DIFF
--- a/src/Checker/EsiTokenValidator.php
+++ b/src/Checker/EsiTokenValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -148,7 +148,7 @@ class EsiTokenValidator
     {
         return new ClaimCheckerManager([
             new IssuerChecker([
-                Configuration::getInstance()->sso_host,
+                sprintf('%s://%s', Configuration::getInstance()->sso_scheme, Configuration::getInstance()->sso_host),
             ]),
             new ExpirationTimeChecker(),
             new AudienceChecker('EVE Online'),

--- a/src/Checker/EsiTokenValidator.php
+++ b/src/Checker/EsiTokenValidator.php
@@ -148,7 +148,8 @@ class EsiTokenValidator
     {
         return new ClaimCheckerManager([
             new IssuerChecker([
-                sprintf('%s://%s', Configuration::getInstance()->sso_scheme, Configuration::getInstance()->sso_host),
+                sprintf('%s://%s', Configuration::getInstance()->sso_scheme, Configuration::getInstance()->sso_host), // the currently used iss claim
+                Configuration::getInstance()->sso_host, // just to be sure, still allow the old claim without protocol
             ]),
             new ExpirationTimeChecker(),
             new AudienceChecker('EVE Online'),

--- a/tests/Fetchers/FetcherTest.php
+++ b/tests/Fetchers/FetcherTest.php
@@ -348,7 +348,7 @@ class FetcherTest extends TestCase
             'name' => 'Warlof Tutsimo',
             'owner' => 'svnSjVa1uGYyp/ZL3mfkIwkJYzQ=',
             'exp'   => $time + 3600,
-            'iss' => 'login.eveonline.com',
+            'iss' => 'https://login.eveonline.com',
         ]);
 
         $builder = new JWSBuilder($manager);


### PR DESCRIPTION
This PR fixes the jwt iss claim for the newer 3.0 version used by seat 5. Since seat 5 depends on eseye for jwt validation, this patch alone is enough