### PR TITLE
access token generation

### DIFF
--- a/src/Access/AccessTokenRefresher.php
+++ b/src/Access/AccessTokenRefresher.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Seat\Eseye\Access;
+
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Seat\Eseye\Checker\EsiTokenValidator;
+use Seat\Eseye\Configuration;
+use Seat\Eseye\Containers\EsiAuthentication;
+use Seat\Eseye\Containers\EsiResponse;
+use Seat\Eseye\Eseye;
+use Seat\Eseye\Exceptions\DiscoverServiceNotAvailableException;
+use Seat\Eseye\Exceptions\InvalidAuthenticationException;
+use Seat\Eseye\Exceptions\InvalidContainerDataException;
+use Seat\Eseye\Exceptions\RequestFailedException;
+
+class AccessTokenRefresher implements AccessTokenRefresherInterface
+{
+    /**
+     * @var StreamFactoryInterface
+     */
+    private StreamFactoryInterface $stream_factory;
+
+    /**
+     * @var RequestFactoryInterface
+     */
+    private RequestFactoryInterface $request_factory;
+
+    /**
+     * @var string
+     */
+    protected string $sso_base;
+
+    /**
+     * @var ClientInterface
+     */
+    protected ClientInterface $client;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected LoggerInterface $logger;
+
+    /**
+     * @var EsiTokenValidator
+     */
+    protected EsiTokenValidator $jwt_validator;
+
+    /**
+     * @throws InvalidContainerDataException
+     */
+    public function __construct()
+    {
+        // Init the logger
+        $this->logger = Configuration::getInstance()->getLogger();
+
+        $this->client = Configuration::getInstance()->getHttpClient();
+        $this->stream_factory = Configuration::getInstance()->getHttpStreamFactory();
+        $this->request_factory = Configuration::getInstance()->getHttpRequestFactory();
+
+        // Init SSO base URI
+        $this->sso_base = sprintf('%s://%s:%d/v2/oauth',
+            Configuration::getInstance()->sso_scheme,
+            Configuration::getInstance()->sso_host,
+            Configuration::getInstance()->sso_port);
+
+        // Init JWT validator
+        $this->jwt_validator = new EsiTokenValidator();
+    }
+
+    /**
+     * @throws DiscoverServiceNotAvailableException
+     * @throws InvalidContainerDataException
+     * @throws RequestFailedException
+     * @throws ClientExceptionInterface
+     * @throws InvalidAuthenticationException
+     */
+    public function getValidAccessToken(EsiAuthentication $authentication): EsiAuthentication
+    {
+        // Check the expiry date.
+        $expires = carbon($authentication->token_expires);
+
+        // If the token expires in the next minute, refresh it.
+        if ($expires->lte(carbon('now')->addMinute())) {
+            $authentication = $this->refreshToken($authentication);
+        }
+
+        return $authentication;
+    }
+
+    /**
+     * Refresh the Access token that we have in the EsiAccess container.
+     *
+     * @throws InvalidContainerDataException
+     * @throws ClientExceptionInterface
+     * @throws RequestFailedException
+     * @throws DiscoverServiceNotAvailableException
+     * @throws InvalidAuthenticationException
+     */
+    private function refreshToken(EsiAuthentication $authentication): EsiAuthentication
+    {
+        // Make the post request for a new access_token
+        $stream = $this->stream_factory->createStream($this->getRefreshTokenForm($authentication));
+
+        $request = $this->request_factory->createRequest('POST', $this->sso_base . '/token')
+            ->withHeader('Authorization', $this->getBasicAuthorizationHeader($authentication))
+            ->withHeader('User-Agent', 'Eseye/' . Eseye::VERSION . '/' . Configuration::getInstance()->http_user_agent)
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($stream);
+
+        $response = $this->client->sendRequest($request);
+
+        // Grab the body from the StreamInterface instance.
+        $content = $response->getBody()->getContents();
+
+        // Client or Server Exception
+        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
+            // Log the event as failed
+            $this->logger->error('[http ' . $response->getStatusCode() . ', ' .
+                strtolower($response->getReasonPhrase()) . '] ' .
+                'get -> ' . $this->sso_base . '/token'
+            );
+
+            // For debugging purposes, log the response body
+            $this->logger->debug('Request for get -> ' . $this->sso_base . '/token failed. Response body was: ' .
+                $content);
+
+            // Raise the exception that should be handled by the caller
+            throw new RequestFailedException(new EsiResponse(
+                $content,
+                $response->getHeaders(),
+                'now',
+                $response->getStatusCode())
+            );
+        }
+
+        $json = json_decode($content);
+
+        $claims = $this->jwt_validator->validateToken($authentication->client_id, $json->access_token);
+        $this->logger->debug('Successfully validate delivered token', [
+            'claims' => $claims,
+        ]);
+
+        // Set the new authentication values from the request
+        $authentication->access_token = $json->access_token;
+        $authentication->refresh_token = $json->refresh_token;
+        $authentication->token_expires = $claims['exp'];
+        $authentication->scopes = $claims['scp'];
+
+        return $authentication;
+    }
+
+    /**
+     * @param EsiAuthentication $authentication
+     * @return string
+     */
+    private function getRefreshTokenForm(EsiAuthentication $authentication): string
+    {
+        $form = [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $authentication->refresh_token,
+        ];
+
+        return http_build_query($form);
+    }
+
+    /**
+     * @return string
+     */
+    private function getBasicAuthorizationHeader(EsiAuthentication $authentication): string
+    {
+        return 'Basic ' . base64_encode($authentication->client_id . ':' . $authentication->secret);
+    }
+}

--- a/src/Access/AccessTokenRefresher.php
+++ b/src/Access/AccessTokenRefresher.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eseye\Access;
 
 use Psr\Http\Client\ClientExceptionInterface;
@@ -154,7 +174,7 @@ class AccessTokenRefresher implements AccessTokenRefresherInterface
     }
 
     /**
-     * @param EsiAuthentication $authentication
+     * @param  EsiAuthentication  $authentication
      * @return string
      */
     private function getRefreshTokenForm(EsiAuthentication $authentication): string

--- a/src/Access/AccessTokenRefresherInterface.php
+++ b/src/Access/AccessTokenRefresherInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Seat\Eseye\Access;
+
+use Seat\Eseye\Containers\EsiAuthentication;
+
+interface AccessTokenRefresherInterface
+{
+    public function getValidAccessToken(EsiAuthentication $authentication): EsiAuthentication;
+}

--- a/src/Access/AccessTokenRefresherInterface.php
+++ b/src/Access/AccessTokenRefresherInterface.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Eseye\Access;
 
 use Seat\Eseye\Containers\EsiAuthentication;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -27,6 +27,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
+use Seat\Eseye\Access\AccessTokenRefresherInterface;
 use Seat\Eseye\Containers\EsiConfiguration;
 use Seat\Eseye\Exceptions\InvalidConfigurationException;
 
@@ -86,6 +87,11 @@ class Configuration
      * @var \Psr\Http\Message\RequestFactoryInterface|string|null
      */
     protected RequestFactoryInterface|string|null $http_request_factory = null;
+
+    /**
+     * @var AccessTokenRefresherInterface|null
+     */
+    protected AccessTokenRefresherInterface|null $access_token_refresher = null;
 
     /**
      * @var EsiConfiguration
@@ -161,6 +167,16 @@ class Configuration
         }
 
         return $this->cache;
+    }
+
+    public function getAccessTokenRefresher(): AccessTokenRefresherInterface
+    {
+        if (! $this->access_token_refresher) {
+            $this->access_token_refresher = is_string($this->configuration->access_token_refresher) ?
+                new $this->configuration->access_token_refresher : $this->configuration->access_token_refresher;
+        }
+
+        return $this->access_token_refresher;
     }
 
     /**

--- a/src/Containers/EsiConfiguration.php
+++ b/src/Containers/EsiConfiguration.php
@@ -24,6 +24,7 @@ namespace Seat\Eseye\Containers;
 
 use GuzzleHttp\Psr7\HttpFactory;
 use Psr\Http\Client\ClientInterface;
+use Seat\Eseye\Access\AccessTokenRefresher;
 use Seat\Eseye\Cache\NullCache;
 use Seat\Eseye\Fetchers\Fetcher;
 use Seat\Eseye\Log\NullLogger;
@@ -63,6 +64,7 @@ class EsiConfiguration extends AbstractArrayAccess
         'sso_scheme'                 => 'https',
         'sso_host'                   => 'login.eveonline.com',
         'sso_port'                   => 443,
+        'access_token_refresher'     => AccessTokenRefresher::class,
 
         // Fetcher
         'fetcher'                    => Fetcher::class,

--- a/src/Containers/EsiConfiguration.php
+++ b/src/Containers/EsiConfiguration.php
@@ -52,51 +52,51 @@ class EsiConfiguration extends AbstractArrayAccess
      * @var array
      */
     protected array $data = [
-        'http_user_agent'            => 'Eseye Default Library',
+        'http_user_agent' => 'Eseye Default Library',
 
         // Esi
-        'datasource'                 => 'tranquility',
-        'esi_scheme'                 => 'https',
-        'esi_host'                   => 'esi.evetech.net',
-        'esi_port'                   => 443,
+        'datasource' => 'tranquility',
+        'esi_scheme' => 'https',
+        'esi_host' => 'esi.evetech.net',
+        'esi_port' => 443,
 
         // Eve Online SSO
-        'sso_scheme'                 => 'https',
-        'sso_host'                   => 'login.eveonline.com',
-        'sso_port'                   => 443,
-        'access_token_refresher'     => AccessTokenRefresher::class,
+        'sso_scheme' => 'https',
+        'sso_host' => 'login.eveonline.com',
+        'sso_port' => 443,
+        'access_token_refresher' => AccessTokenRefresher::class,
 
         // Fetcher
-        'fetcher'                    => Fetcher::class,
+        'fetcher' => Fetcher::class,
 
         // Logging
-        'logger'                     => NullLogger::class,
-        'logger_level'               => 'INFO',
-        'logfile_location'           => 'logs/',
+        'logger' => NullLogger::class,
+        'logger_level' => 'INFO',
+        'logfile_location' => 'logs/',
 
         // Rotating Logger Details
-        'log_max_files'              => 10,
+        'log_max_files' => 10,
 
         // Cache
-        'cache'                      => NullCache::class,
+        'cache' => NullCache::class,
 
         // File Cache
-        'file_cache_location'        => 'cache/',
+        'file_cache_location' => 'cache/',
 
         // Redis Cache
-        'redis_cache_location'       => 'tcp://127.0.0.1',
-        'redis_cache_prefix'         => 'eseye:',
+        'redis_cache_location' => 'tcp://127.0.0.1',
+        'redis_cache_prefix' => 'eseye:',
 
         // Memcached Cache
-        'memcached_cache_host'       => '127.0.0.1',
-        'memcached_cache_port'       => '11211',
-        'memcached_cache_prefix'     => 'eseye:',
+        'memcached_cache_host' => '127.0.0.1',
+        'memcached_cache_port' => '11211',
+        'memcached_cache_prefix' => 'eseye:',
         'memcached_cache_compressed' => false,
 
         // HTTP
-        'http_client'                => ClientInterface::class,
-        'http_request_factory'       => HttpFactory::class,
-        'http_stream_factory'        => HttpFactory::class,
+        'http_client' => ClientInterface::class,
+        'http_request_factory' => HttpFactory::class,
+        'http_stream_factory' => HttpFactory::class,
     ];
 
 }

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -27,6 +27,8 @@ use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Seat\Eseye\Access\AccessInterface;
+use Seat\Eseye\Access\AccessTokenRefresher;
+use Seat\Eseye\Access\AccessTokenRefresherInterface;
 use Seat\Eseye\Access\CheckAccess;
 use Seat\Eseye\Containers\EsiAuthentication;
 use Seat\Eseye\Containers\EsiResponse;
@@ -149,6 +151,15 @@ class Eseye
         $this->access_checker = $checker;
 
         return $this;
+    }
+
+
+    /**
+     * @throws InvalidContainerDataException
+     */
+    public function getAccessTokenRefresher(): AccessTokenRefresherInterface
+    {
+        return $this->getConfiguration()->getAccessTokenRefresher();
     }
 
     /**
@@ -535,5 +546,15 @@ class Eseye
         $this->setQueryString(['page' => $page]);
 
         return $this;
+    }
+
+    /**
+     * @return EsiAuthentication
+     * @throws InvalidAuthenticationException
+     * @throws InvalidContainerDataException
+     */
+    public function getValidAccessToken(): EsiAuthentication
+    {
+        return $this->getAccessTokenRefresher()->getValidAccessToken($this->getAuthentication());
     }
 }

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -27,7 +27,6 @@ use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Seat\Eseye\Access\AccessInterface;
-use Seat\Eseye\Access\AccessTokenRefresher;
 use Seat\Eseye\Access\AccessTokenRefresherInterface;
 use Seat\Eseye\Access\CheckAccess;
 use Seat\Eseye\Containers\EsiAuthentication;
@@ -152,7 +151,6 @@ class Eseye
 
         return $this;
     }
-
 
     /**
      * @throws InvalidContainerDataException
@@ -370,10 +368,10 @@ class Eseye
 
         return Uri::fromParts([
             'scheme' => $this->getConfiguration()->esi_scheme,
-            'host'   => $this->getConfiguration()->esi_host,
-            'port'   => $this->getConfiguration()->esi_port,
-            'path'   => rtrim($this->getVersion(), '/') . $this->mapDataToUri($endpoint, $data),
-            'query'  => http_build_query($query_params),
+            'host' => $this->getConfiguration()->esi_host,
+            'port' => $this->getConfiguration()->esi_port,
+            'path' => rtrim($this->getVersion(), '/') . $this->mapDataToUri($endpoint, $data),
+            'query' => http_build_query($query_params),
         ]);
     }
 
@@ -550,6 +548,7 @@ class Eseye
 
     /**
      * @return EsiAuthentication
+     *
      * @throws InvalidAuthenticationException
      * @throws InvalidContainerDataException
      */

--- a/src/Fetchers/Fetcher.php
+++ b/src/Fetchers/Fetcher.php
@@ -29,6 +29,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Seat\Eseye\Access\AccessTokenRefresherInterface;
 use Seat\Eseye\Checker\EsiTokenValidator;
 use Seat\Eseye\Configuration;
 use Seat\Eseye\Containers\EsiAuthentication;
@@ -58,6 +59,11 @@ class Fetcher implements FetcherInterface
      * @var \Psr\Log\LoggerInterface
      */
     protected LoggerInterface $logger;
+
+    /**
+     * @var AccessTokenRefresherInterface
+     */
+    protected AccessTokenRefresherInterface $access_token_refresher;
 
     /**
      * @var string
@@ -92,6 +98,7 @@ class Fetcher implements FetcherInterface
         $this->client = Configuration::getInstance()->getHttpClient();
         $this->stream_factory = Configuration::getInstance()->getHttpStreamFactory();
         $this->request_factory = Configuration::getInstance()->getHttpRequestFactory();
+        $this->access_token_refresher = Configuration::getInstance()->getAccessTokenRefresher();
 
         // Init SSO base URI
         $this->sso_base = sprintf('%s://%s:%d/v2/oauth',
@@ -166,88 +173,11 @@ class Fetcher implements FetcherInterface
             throw new InvalidAuthenticationException(
                 'Trying to get a token without authentication data.');
 
-        // Check the expiry date.
-        $expires = carbon($this->getAuthentication()->token_expires);
-
-        // If the token expires in the next minute, refresh it.
-        if ($expires->lte(carbon('now')->addMinute()))
-            $this->refreshToken();
+        // make sure our access token is up-to-date
+        $authentication = $this->access_token_refresher->getValidAccessToken($this->getAuthentication());
+        $this->setAuthentication($authentication);
 
         return $this->getAuthentication()->access_token;
-    }
-
-    /**
-     * Refresh the Access token that we have in the EsiAccess container.
-     *
-     * @throws \Seat\Eseye\Exceptions\InvalidContainerDataException
-     * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \Seat\Eseye\Exceptions\RequestFailedException
-     * @throws \Seat\Eseye\Exceptions\DiscoverServiceNotAvailableException
-     * @throws \Seat\Eseye\Exceptions\InvalidAuthenticationException
-     */
-    private function refreshToken(): void
-    {
-        // Make the post request for a new access_token
-        $stream = $this->stream_factory->createStream($this->getRefreshTokenForm());
-
-        $request = $this->request_factory->createRequest('POST', $this->sso_base . '/token')
-            ->withHeader('Authorization', $this->getBasicAuthorizationHeader())
-            ->withHeader('User-Agent', 'Eseye/' . Eseye::VERSION . '/' . Configuration::getInstance()->http_user_agent)
-            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
-            ->withBody($stream);
-
-        $response = $this->getClient()->sendRequest($request);
-
-        // Grab the body from the StreamInterface instance.
-        $content = $response->getBody()->getContents();
-
-        // Client or Server Exception
-        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
-            // Log the event as failed
-            $this->logger->error('[http ' . $response->getStatusCode() . ', ' .
-                strtolower($response->getReasonPhrase()) . '] ' .
-                'get -> ' . $this->sso_base . '/token'
-            );
-
-            // For debugging purposes, log the response body
-            $this->logger->debug('Request for get -> ' . $this->sso_base . '/token failed. Response body was: ' .
-                $content);
-
-            // Raise the exception that should be handled by the caller
-            throw new RequestFailedException($this->makeEsiResponse(
-                $content,
-                $response->getHeaders(),
-                'now',
-                $response->getStatusCode())
-            );
-        }
-
-        $json = json_decode($content);
-
-        // Get the current EsiAuth container
-        $authentication = $this->getAuthentication();
-
-        $claims = $this->jwt_validator->validateToken($authentication->client_id, $json->access_token);
-        $this->logger->debug('Successfully validate delivered token', [
-            'claims' => $claims,
-        ]);
-
-        // Set the new authentication values from the request
-        $authentication->access_token = $json->access_token;
-        $authentication->refresh_token = $json->refresh_token;
-        $authentication->token_expires = $claims['exp'];
-        $authentication->scopes = $claims['scp'];
-
-        // ... and update the container
-        $this->setAuthentication($authentication);
-    }
-
-    /**
-     * @return string
-     */
-    private function getBasicAuthorizationHeader(): string
-    {
-        return 'Basic ' . base64_encode($this->authentication->client_id . ':' . $this->authentication->secret);
     }
 
     /**
@@ -262,19 +192,6 @@ class Fetcher implements FetcherInterface
     private function getBearerAuthorizationHeader(): string
     {
         return 'Bearer ' . $this->getToken();
-    }
-
-    /**
-     * @return string
-     */
-    private function getRefreshTokenForm(): string
-    {
-        $form = [
-            'grant_type' => 'refresh_token',
-            'refresh_token' => $this->authentication->refresh_token,
-        ];
-
-        return http_build_query($form);
     }
 
     /**

--- a/src/Fetchers/Fetcher.php
+++ b/src/Fetchers/Fetcher.php
@@ -211,9 +211,9 @@ class Fetcher implements FetcherInterface
         // Include some basic headers to those already passed in. Everything
         // is considered to be json.
         $headers = array_merge($headers, [
-            'Accept'       => 'application/json',
+            'Accept' => 'application/json',
             'Content-Type' => 'application/json',
-            'User-Agent'   => 'Eseye/' . Eseye::VERSION . '/' . Configuration::getInstance()->http_user_agent,
+            'User-Agent' => 'Eseye/' . Eseye::VERSION . '/' . Configuration::getInstance()->http_user_agent,
         ]);
 
         // Add some debug logging and start measuring how long the request took.


### PR DESCRIPTION
This PR allows seat to refresh an access token without making an esi call, for example for tokens that only have the `publicData` scope.

Since I don't want to have a major release just for this, we can't modify the fetcher interface (that currently hold the access token refresh logic) and add a new method to refresh the access token. Therefore, I extracted all the access token refresh logic from the fetcher into a new AccessTokenRefresher class. The fetcher uses that to get access tokens.

The Eseye class itself doesn't implement an interface, so we can just add a method to refresh the access token in there. Internally, it also uses the AccessTokenRefresher