### PR TITLE
Bye ESI versions, Hello compatibility date

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ Its supposed to be simple!
 // initialization stuff
 $esi = new Eseye();
 
-// Optionally, set the ESI endpoint version to use.
-// If you dont set this, Eseye will use /latest
-$esi->setVersion('v4');
-
 // make a call
 $character_info = $esi->invoke('get', '/characters/{character_id}/', [
     'character_id' => 1477919642,

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -76,6 +76,11 @@ class Eseye
     protected array $request_body = [];
 
     /**
+     * @var string
+     */
+    protected string $compatibility_date = "2025-07-20";
+
+    /**
      * HTTP verbs that could have their responses cached.
      *
      * @var array
@@ -297,6 +302,27 @@ class Eseye
     }
 
     /**
+     * Set the date for the X-Compatibility-Date header
+     *
+     * @param string $date
+     * @return void
+     */
+    public function setCompatibilityDate(string $date): void
+    {
+        $this->compatibility_date = $date;
+    }
+
+    /**
+     * Get the date for the X-Compatibility-Date header
+     *
+     * @return string
+     */
+    public function getCompatibilityDate(): string
+    {
+        return $this->compatibility_date;
+    }
+
+    /**
      * @param  string  $method
      * @param  string  $uri
      * @param  array  $uri_data
@@ -330,7 +356,9 @@ class Eseye
 
         // Call ESI itself and get the EsiResponse in case it has not already been handled with cache control
         if (! isset($result))
-            $result = $this->rawFetch($method, $uri, $this->getBody());
+            $result = $this->rawFetch($method, $uri, $this->getBody(),[
+                'X-Compatibility-Date' => $this->compatibility_date
+            ]);
 
         // Cache the response if it was a get and is not already expired
         if ($this->isCachable($method, $result))
@@ -453,7 +481,10 @@ class Eseye
         // Sending a request with the stored ETag in header - if we have a 304 response, data has not been altered.
         if ($cache_entry->hasHeader('ETag') && $cache_entry->expired()) {
 
-            $result = $this->rawFetch($method, $uri, $this->getBody(), ['If-None-Match' => $cache_entry->getHeader('ETag')]);
+            $result = $this->rawFetch($method, $uri, $this->getBody(), [
+                'If-None-Match' => $cache_entry->getHeader('ETag'),
+                'X-Compatibility-Date' => $this->compatibility_date
+            ]);
 
             // in case response was distinct from 304 (unmodified) - return it directly
             if ($result->getErrorCode() !== 304)

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -78,7 +78,7 @@ class Eseye
     /**
      * @var string
      */
-    protected string $compatibility_date = "2025-07-20";
+    protected string $compatibility_date = '2025-07-20';
 
     /**
      * HTTP verbs that could have their responses cached.
@@ -94,7 +94,7 @@ class Eseye
      *
      * @throws \Seat\Eseye\Exceptions\InvalidContainerDataException
      */
-    public function __construct(EsiAuthentication $authentication = null)
+    public function __construct(?EsiAuthentication $authentication = null)
     {
         if (! is_null($authentication))
             $this->authentication = $authentication;
@@ -285,7 +285,7 @@ class Eseye
      */
     public function getVersion(): string
     {
-        return "/latest";
+        return '/latest';
     }
 
     /**
@@ -302,9 +302,9 @@ class Eseye
     }
 
     /**
-     * Set the date for the X-Compatibility-Date header
+     * Set the date for the X-Compatibility-Date header.
      *
-     * @param string $date
+     * @param  string  $date
      * @return void
      */
     public function setCompatibilityDate(string $date): void
@@ -313,7 +313,7 @@ class Eseye
     }
 
     /**
-     * Get the date for the X-Compatibility-Date header
+     * Get the date for the X-Compatibility-Date header.
      *
      * @return string
      */
@@ -356,8 +356,8 @@ class Eseye
 
         // Call ESI itself and get the EsiResponse in case it has not already been handled with cache control
         if (! isset($result))
-            $result = $this->rawFetch($method, $uri, $this->getBody(),[
-                'X-Compatibility-Date' => $this->compatibility_date
+            $result = $this->rawFetch($method, $uri, $this->getBody(), [
+                'X-Compatibility-Date' => $this->compatibility_date,
             ]);
 
         // Cache the response if it was a get and is not already expired
@@ -483,7 +483,7 @@ class Eseye
 
             $result = $this->rawFetch($method, $uri, $this->getBody(), [
                 'If-None-Match' => $cache_entry->getHeader('ETag'),
-                'X-Compatibility-Date' => $this->compatibility_date
+                'X-Compatibility-Date' => $this->compatibility_date,
             ]);
 
             // in case response was distinct from 304 (unmodified) - return it directly

--- a/src/Eseye.php
+++ b/src/Eseye.php
@@ -76,11 +76,6 @@ class Eseye
     protected array $request_body = [];
 
     /**
-     * @var string
-     */
-    protected string $version = '/latest';
-
-    /**
      * HTTP verbs that could have their responses cached.
      *
      * @var array
@@ -277,28 +272,27 @@ class Eseye
     }
 
     /**
-     * Get the versioned baseURI to use.
+     * Get the versioned baseURI to use. Since ESI no longer uses versioned endpoints, this just returns a default value.
+     *
+     * @deprecated ESI no longer uses versioned endpoints. This method will be removed in eseye 4.0
      *
      * @return string
      */
     public function getVersion(): string
     {
-        return $this->version;
+        return "/latest";
     }
 
     /**
-     * Set the version of the API endpoints base URI.
+     * Set the version of the API endpoints base URI. Since ESI no longer uses versioned endpoints, this method does nothing but is retained for compatibility.
+     *
+     * @deprecated ESI no longer uses versioned endpoints. This method will be removed in eseye 4.0
      *
      * @param  string  $version
      * @return \Seat\Eseye\Eseye
      */
     public function setVersion(string $version): Eseye
     {
-        if (! str_starts_with($version, '/'))
-            $version = '/' . $version;
-
-        $this->version = $version;
-
         return $this;
     }
 
@@ -370,7 +364,7 @@ class Eseye
             'scheme' => $this->getConfiguration()->esi_scheme,
             'host' => $this->getConfiguration()->esi_host,
             'port' => $this->getConfiguration()->esi_port,
-            'path' => rtrim($this->getVersion(), '/') . $this->mapDataToUri($endpoint, $data),
+            'path' => $this->mapDataToUri($endpoint, $data),
             'query' => http_build_query($query_params),
         ]);
     }

--- a/tests/EseyeTest.php
+++ b/tests/EseyeTest.php
@@ -241,7 +241,7 @@ class EseyeTest extends TestCase
 
         $uri = $this->esi->buildDataUri('/{foo}/', ['foo' => 'bar']);
 
-        $this->assertEquals('https://esi.evetech.net/latest/bar/?datasource=singularity',
+        $this->assertEquals('https://esi.evetech.net/bar/?datasource=singularity',
             $uri->__toString());
     }
 
@@ -417,6 +417,24 @@ class EseyeTest extends TestCase
         $this->esi->setRefreshToken('ALTERNATE_REFRESH_TOKEN');
 
         $this->assertEquals('ALTERNATE_REFRESH_TOKEN', $this->esi->getAuthentication()->refresh_token);
+    }
+
+    public function testEseyeCompatibilityDateHeader()
+    {
+        self::$http_feed_handler->reset();
+        self::$http_feed_handler->append(
+            new Response(200, ['X-Foo' => 'Bar'], json_encode(['foo' => 'var'])),
+        );
+
+        $this->esi->setCompatibilityDate("2025-01-01");
+        $this->esi->invoke('get', '/universe/regions/', [
+            'character_id' => 123,
+        ]);
+
+        $request_headers = self::$request_logs[count(self::$request_logs)-1]['request']->getHeaders();
+
+        $this->assertArrayHasKey('X-Compatibility-Date',$request_headers);
+        $this->assertEquals('2025-01-01', $request_headers['X-Compatibility-Date'][0]);
     }
 
 }

--- a/tests/EseyeTest.php
+++ b/tests/EseyeTest.php
@@ -236,30 +236,6 @@ class EseyeTest extends TestCase
         $this->assertEquals(['foo'], $this->esi->getBody());
     }
 
-    public function testEseyeGetDefaultVersionString()
-    {
-
-        $version = $this->esi->getVersion();
-
-        $this->assertEquals('/latest', $version);
-    }
-
-    public function testEseyeSetIncompleteVersionStringAndGetsCompleteVersionString()
-    {
-
-        $this->esi->setVersion('v1');
-
-        $this->assertEquals('/v1', $this->esi->getVersion());
-    }
-
-    public function testEseyeReturnsEseyeAfterSettingEsiApiVersion()
-    {
-
-        $esi = $this->esi->setVersion('v4');
-
-        $this->assertInstanceOf(Eseye::class, $esi);
-    }
-
     public function testEseyeBuildValidDataUri()
     {
 


### PR DESCRIPTION
ESI no longer uses versions in the endpoint URL, and as of right now, they also have no effect. See https://developers.eveonline.com/blog/changing-versions-v42-was-getting-out-of-hand

This PR removes esi versions while keeping compatibility with existing code. This is done by effectively turning ->setVersion() and ->getVersion() into no-ops. You can still call them, but they do nothing.

At the same time, this PR introduces the `X-Compatibility-Date` header. You can set it's value using -> setCompatibilityDate(string $date). If no date is set, like with old code, we use the date of this PR so code should stay as compatible as possible.